### PR TITLE
set toolbar fixed false

### DIFF
--- a/assets/redactor.js
+++ b/assets/redactor.js
@@ -189,7 +189,7 @@
 		videoContainerClass: 'video-container',
 
 		toolbar: true,
-		toolbarFixed: true,
+		toolbarFixed: false,
 		toolbarFixedTarget: document,
 		toolbarFixedTopOffset: 0, // pixels
 		toolbarExternal: false, // ID selector


### PR DESCRIPTION
toolbarFixed auf false. Sonst klebt sich die Toolbar bei mehrfach Verwendung in einem Redaxo Modul/Block oben dran ... z.B mblock Accordion (beim scrollen)