### PR TITLE
newline für strg+enter

### DIFF
--- a/assets/redactor.js
+++ b/assets/redactor.js
@@ -6407,8 +6407,15 @@
 				onShiftEnter: function(e)
 				{
 					this.buffer.set();
-
-					return (this.keydown.pre) ? this.keydown.insertNewLine(e) : this.insert.raw('<br>');
+					// immer br und newline bei strg + enter
+					if (this.keydown.pre) {
+						this.keydown.insertNewLine(e);
+					}
+					else {
+						this.insert.raw('<br>');
+						this.keydown.insertNewLine(e);
+					}
+					return false;
 				},
 				onBackspaceAndDeleteBefore: function()
 				{


### PR DESCRIPTION
Redactor erlaubt das Einfügen von Zeilenumbrüchen per STRG+ENTER oder SHIFT+ENTER. Im Editor wird dann ein `<br>` eingefügt. Das setzt aber leider oft nicht den Cursor per `\n` in die nächste Zeile, spätenstens wenn ich einen kompletten Absatz über Backspace lösche klappts reproduzierbar nicht mehr. Dann drückt der Redakteur 2x STRG+ENTER um den Cursor in die nächste Zeile zu kriegen und hat 2x `<br>`.

Der PR setzt bei STRG+ENTER nach dem `<br>` zusätzlich ein `\n`, so dass die visuelle Ausgabe des Editors zur Eingabe passt. Einzige Nebenwirkung sind natürlich mehr `\n`, die kann man aber ohne weiteres vor dem Speichern rausfiltern.

Da anscheinend nur Lizenzinhaber Bugs reporten können, reich ich dir das mal vertrauensvoll rüber :)